### PR TITLE
Add initial makefile framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+
+###############################################################################
+#
+# Copyright...
+#
+#
+###############################################################################
+
+###############################################################################
+# Default Build targets
+###############################################################################
+.DEFAULT_GOAL := all
+all: debug release
+
+# Inclusion of per architecture build targets
+include src/tools/beaglebone.mk
+include src/tools/native.mk
+
+.PHONY : setup
+setup: setup-debug setup-release
+
+.PHONY : setup-debug
+setup-debug: setup-beaglebone-debug setup-native-debug
+
+.PHONY : setup-release
+setup-release: setup-beaglebone-release setup-native-release
+
+.PHONY : debug
+debug: beaglebone-debug native-debug
+
+.PHONY : release
+release: beaglebone-release native-release
+
+.PHONY : clean
+clean: 
+	rm -rf build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(feedback-control)
+
+add_executable(test
+    main.cpp
+)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,7 @@
+
+#include <iostream>
+
+int main(int argc, const char * argv[])
+{
+    std::cout << "Blah" << std::endl;
+}

--- a/src/tools/beaglebone.mk
+++ b/src/tools/beaglebone.mk
@@ -1,0 +1,40 @@
+###############################################################################
+#
+# Copyright...
+#
+#
+###############################################################################
+
+.PHONY : setup-beaglebone
+setup-beaglebone: setup-beaglebone-debug setup-beaglebone-release
+
+.PHONY : setup-beaglebone-debug
+setup-beaglebone-debug:
+	. /opt/poky/4.0.4/environment-setup-cortexa8hf-neon-poky-linux-gnueabi && \
+	cmake \
+		-DCMAKE_TOOLCHAIN_FILE=/opt/poky/4.0.4/sysroots/x86_64-pokysdk-linux/usr/share/cmake/OEToolchainConfig.cmake \
+		-B build/beaglebone/debug \
+		-S src/ \
+		-DCMAKE_BUILD_TYPE=DEBUG
+
+.PHONY : setup-beaglebone-release
+setup-beaglebone-release:
+	. /opt/poky/4.0.4/environment-setup-cortexa8hf-neon-poky-linux-gnueabi && \
+	cmake \
+		-DCMAKE_TOOLCHAIN_FILE=/opt/poky/4.0.4/sysroots/x86_64-pokysdk-linux/usr/share/cmake/OEToolchainConfig.cmake \
+		-B build/beaglebone/release \
+		-S src/ \
+		-DCMAKE_BUILD_TYPE=RELEASE
+
+.PHONY : beaglebone
+beaglebone: beaglebone-debug beaglebone-release
+
+.PHONY : beaglebone-debug
+beaglebone-debug: setup-beaglebone-debug
+	cmake \
+		--build build/beaglebone/debug
+
+.PHONY : release
+beaglebone-release: setup-beaglebone-release
+	cmake \
+		--build build/beaglebone/release

--- a/src/tools/native.mk
+++ b/src/tools/native.mk
@@ -1,0 +1,36 @@
+###############################################################################
+#
+# Copyright...
+#
+#
+###############################################################################
+
+.PHONY : setup-native
+setup-native: setup-native-debug setup-native-release
+
+.PHONY : setup-native-debug
+setup-native-debug:
+	cmake \
+		-B build/native/debug \
+		-S src/ \
+		-DCMAKE_BUILD_TYPE=DEBUG
+
+.PHONY : setup-native-release
+setup-native-release:
+	cmake \
+		-B build/native/release \
+		-S src/ \
+		-DCMAKE_BUILD_TYPE=RELEASE
+
+.PHONY : native
+native: native-debug native-release
+
+.PHONY : native-debug
+native-debug: setup-native-debug
+	cmake \
+		--build build/native/debug
+
+.PHONY : release
+native-release: setup-native-release
+	cmake \
+		--build build/native/release


### PR DESCRIPTION
This setup uses Make as an entrypoint, cmake as the business end and supports both native and cross compile builds using a yocto generated sdk.